### PR TITLE
npm postinstall step to run grunt default task

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ js-test-workshop
 Demo project for exercises
 
 Uses Jasmine, Karma and Mockjax
+
+Getting started
+---------------
+
+    npm install

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "author": "Lars Thorup <lars@zealake.com>",
     "engine": "node 1.1.x",
     "devDependencies": {
-        "grunt-cli": "^0.1.6",
         "grunt": "^0.4.4",
         "grunt-contrib-clean": "^0.6.0",
         "grunt-contrib-jshint": "^0.11.0",
@@ -21,6 +20,7 @@
         "coveralls": "^2.11.1"
     },
     "scripts": {
+        "postinstall": "grunt",
         "coveralls": "cat ./output/coverage/*/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
         "travis": "grunt ci && npm run coveralls"
     }


### PR DESCRIPTION
Using postinstall step to actually run grunt default task

This makes you get started with less steps (there is only a step 1)

For documentation on npm `postinstall` step see https://docs.npmjs.com/misc/scripts
