### PR TITLE
Separate JSHint file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,11 +21,11 @@
 "maxparams": 3,
 "maxdepth": 2,
 "maxstatements": 50,
+"jquery": true,
+"browser": true,
 "globals": {
-    "jQuery": true,
     "Math": true,
     "module": true,
-    "window": true,
 
     "afterEach": true,
     "beforeEach": true,
@@ -33,9 +33,7 @@
     "expect": true,
     "it": true,
     "jasmine": true,
-
     "spyOn": true,
-    "xit": true,
-    "$": true
+    "xit": true
   }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,41 @@
+{
+"bitwise": true,
+"camelcase": true,
+"curly": true,
+"eqeqeq": true,
+"forin": true,
+"immed": true,
+"indent": 5,
+"latedef": true,
+"newcap": true,
+"noarg": true,
+"noempty": true,
+"nonew": true,
+"plusplus": true,
+"quotmark": true,
+"regexp": true,
+"undef": true,
+"unused": true,
+"strict": true,
+"trailing": true,
+"maxparams": 3,
+"maxdepth": 2,
+"maxstatements": 50,
+"globals": {
+    "jQuery": true,
+    "Math": true,
+    "module": true,
+    "window": true,
+
+    "afterEach": true,
+    "beforeEach": true,
+    "describe": true,
+    "expect": true,
+    "it": true,
+    "jasmine": true,
+
+    "spyOn": true,
+    "xit": true,
+    "$": true
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,29 +23,14 @@ module.exports = function (grunt) {
     // lint
     grunt.loadNpmTasks('grunt-contrib-jshint');
     gruntConfig.jshint = {
-        options: { bitwise: true, camelcase: true, curly: true, eqeqeq: true, forin: true, immed: true,
-            indent: 4, latedef: true, newcap: true, noarg: true, noempty: true, nonew: true, plusplus: true,
-            quotmark: true, regexp: true, undef: true, unused: true, strict: true, trailing: true,
-            maxparams: 3, maxdepth: 2, maxstatements: 50, globals: {
-                afterEach: true,
-                beforeEach: true,
-                describe: true,
-                expect: true,
-                it: true,
-                jasmine: true,
-                jQuery: true,
-                Math: true,
-                module: true,
-                spyOn: true,
-                window: true,
-                xit: true,
-                '$': true
-            }},
         all: [
             'Gruntfile.js',
             'src/js/**/*.js',
             'test/js/**/*.js'
-        ]
+        ],
+      options: {
+        jshintrc: '.jshintrc',
+      }
     };
     grunt.registerTask('lint', 'jshint');
 


### PR DESCRIPTION
- [x] moved jshint options to separate file so that IDE linters also can read it
- [x] jQuery and $ globals moved to jshint option for 'jquery'
- [x] window global moved to jshint option for 'browser'
